### PR TITLE
Image sizes

### DIFF
--- a/Campfire.colloquyStyle/Contents/Resources/main.css
+++ b/Campfire.colloquyStyle/Contents/Resources/main.css
@@ -18,7 +18,7 @@ img {
 	padding-top: 5px;
 	padding-bottom: 5px;
 	padding-left: 8px;
-	max-width: 100%;
+	max-width: 300px;
 }
 
 a:link, a:visited, a:hover, a:active {

--- a/Campfire.colloquyStyle/Contents/Resources/main.css
+++ b/Campfire.colloquyStyle/Contents/Resources/main.css
@@ -18,7 +18,8 @@ img {
 	padding-top: 5px;
 	padding-bottom: 5px;
 	padding-left: 8px;
-	max-width: 300px;
+	max-height: 300px;
+	max-width: 485px; /* Golden ratio ~ 485/300 */
 }
 
 a:link, a:visited, a:hover, a:active {

--- a/Campfire.colloquyStyle/Contents/Resources/main.xsl
+++ b/Campfire.colloquyStyle/Contents/Resources/main.xsl
@@ -187,22 +187,22 @@
 
 		<xsl:choose>
 			<xsl:when test="$extension = '.jpg' or $extension = '.JPG' or $extensionLong = '.jpeg' or $extensionLong = '.JPEG'">
-				<a href="{@href}" title="{@href}"><img src="{@href}" width="300" alt="Loading Image..." onload="scrollToBottom()" /></a>
+				<a href="{@href}" title="{@href}"><img src="{@href}" alt="Loading Image..." onload="scrollToBottom()" /></a>
 			</xsl:when>
 			<xsl:when test="$extension = '.gif' or $extension = '.GIF'">
-				<a href="{@href}" title="{@href}"><img src="{@href}" width="300" alt="Loading Image..." onload="scrollToBottom()" /></a>
+				<a href="{@href}" title="{@href}"><img src="{@href}" alt="Loading Image..." onload="scrollToBottom()" /></a>
 			</xsl:when>
 			<xsl:when test="$extension = '.png' or $extension = '.PNG'">
-				<a href="{@href}" title="{@href}"><img src="{@href}" width="300" alt="Loading Image..." onload="scrollToBottom()" /></a>
+				<a href="{@href}" title="{@href}"><img src="{@href}" alt="Loading Image..." onload="scrollToBottom()" /></a>
 			</xsl:when>
 			<xsl:when test="$extension = '.tif' or $extension = '.TIF' or $extensionLong = '.tiff' or $extensionLong = '.TIFF'">
-				<a href="{@href}" title="{@href}"><img src="{@href}" width="300" alt="Loading Image..." onload="scrollToBottom()" /></a>
+				<a href="{@href}" title="{@href}"><img src="{@href}" alt="Loading Image..." onload="scrollToBottom()" /></a>
 			</xsl:when>
 			<xsl:when test="$extension = '.pdf' or $extension = '.PDF'">
-				<a href="{@href}" title="{@href}"><img src="{@href}" width="300" alt="Loading Image..." onload="scrollToBottom()" /></a>
+				<a href="{@href}" title="{@href}"><img src="{@href}" alt="Loading Image..." onload="scrollToBottom()" /></a>
 			</xsl:when>
 			<xsl:when test="$extension = '.bmp' or $extension = '.BMP'">
-				<a href="{@href}" title="{@href}"><img src="{@href}" width="300" alt="Loading Image..." onload="scrollToBottom()" /></a>
+				<a href="{@href}" title="{@href}"><img src="{@href}" alt="Loading Image..." onload="scrollToBottom()" /></a>
 			</xsl:when>
 			<xsl:otherwise>
 				<xsl:copy-of select="current()"/>


### PR DESCRIPTION
Currently, all images are re-scaled to be 300 pixels wide.

There are two problems that I see with this:
1. Small images look jagged because they are being upscaled from their original smaller size. Commit d0571ee3
2. 300 pixels isn't very big. I propose the max dimensions should be 485 (w) x 300 (h). 485/300 is approx the Golden Ratio (not that it will enforce that ratio on images). I figure if we are going to pick an arbitrary size, might as well pick one that agrees with thousands of years of art history. Commit 18e6fd58

Even if you reject the second commit, the first one is pretty essential.
